### PR TITLE
Added proxied option

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -2,6 +2,7 @@
 TOKEn=myapitoken
 ZONE=example.org
 DNS_RECORD=some.example.org
+PROXIED=false
 
 # Optional
 #CRON=* * * * *

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ KEY=Global_API_Key
 
 ZONE=example.org
 DNS_RECORD=some.example.org
+PROXIED=false
 ```
 
 3. Run the container
@@ -54,6 +55,7 @@ docker-compose up -d
 | `TOKEN`      | API Token that can be used instead of `EMAIL` & `KEY`. |                        |
 | `ZONE`       | Cloudflare zone where your domain is.                  |                        |
 | `DNS_RECORD` | The actual DNS record that should be updated.          |                        |
+| `PROXIED`    | Whether the record is proxied by CloudFlare or not.    |                        |
 | `CRON`       | Frequency of updates.                                  | \*/5 \* \* \* \*       |
 | `RESOLVER`   | The endpoint used to determine your public ip.         | https://api.ipify.org/ |
 


### PR DESCRIPTION
If "proxied" option is not included into the API call, CloudFlare automatically changes the record to "non-proxy". I added a proxy option and tested the code locally. Sorry if something is not right, I am not a developer.